### PR TITLE
Have a minimum bound of 0.3.0

### DIFF
--- a/hedgehog-fakedata.cabal
+++ b/hedgehog-fakedata.cabal
@@ -29,7 +29,7 @@ library
       src
   build-depends:
       base      >=4.7       && <5
-    , fakedata  >= 0.1.0    && < 0.6.0
+    , fakedata  >= 0.3.0    && < 0.6.0
     , hedgehog  >= 0.1      && < 1.1
     , random    >= 1.0.0.0  && < 1.2
   default-language: Haskell2010


### PR DESCRIPTION
Post 0.3.0 has fixed some serious perf issues

More details here: https://psibi.in/posts/2019-09-23-fakedata-perf.html