### PR TITLE
Don't use shrinking for random seed.

### DIFF
--- a/src/Hedgehog/Gen/Faker.hs
+++ b/src/Hedgehog/Gen/Faker.hs
@@ -17,7 +17,7 @@ import qualified Hedgehog.Internal.Seed as InternalSeed
 -- @since 0.0.1.0
 fake :: Fake a -> Gen a
 fake f = do
-    randomGen <- mkStdGen <$> Gen.integral Range.linearBounded
+    randomGen <- mkStdGen <$> Gen.integral_ Range.linearBounded
     pure $!
         unsafePerformIO $
         -- (parsonsmatt): OK so `unsafePerformIO` is bad, unless you know exactly


### PR DESCRIPTION
Using `Gen.integral` here means that this generator will shrink randomly. Shrinking a seed is nonsense, the value doesn't get smaller, and this only increases the time spent finding a minimal counter-example.

`Gen.integral_` does not shrink, and is a much better alternative.