### PR TITLE
Support `hedgehog-1.1`

### DIFF
--- a/hedgehog-fakedata.cabal
+++ b/hedgehog-fakedata.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
       base      >=4.7       && <5
     , fakedata  >= 0.1.0    
-    , hedgehog  >= 0.1      && < 1.1
+    , hedgehog  >= 0.1      && < 1.2
     , random    >= 1.0.0.0  && < 1.3
   default-language: Haskell2010
 


### PR DESCRIPTION
Confirmed to build OK when using `allow-newer`.